### PR TITLE
(patch) modulizer erroneously escaped `attr$=` to `attr\$=`

### DIFF
--- a/cosmoz-datetime-input.js
+++ b/cosmoz-datetime-input.js
@@ -41,12 +41,12 @@ class CosmozDatetimeInput extends PolymerElement {
 
 		<div class="container">
 			<paper-input-container always-float-label>
-				<label hidden\$="[[ !dateLabel ]]" slot="label" aria-hidden="true" for="dateInput">[[ dateLabel ]]</label>
-				<input id="dateInput" type="date" slot="input" value="{{ date::input }}" min\$="[[ _minDate ]]" max\$="[[ _maxDate ]]">
+				<label hidden$="[[ !dateLabel ]]" slot="label" aria-hidden="true" for="dateInput">[[ dateLabel ]]</label>
+				<input id="dateInput" type="date" slot="input" value="{{ date::input }}" min$="[[ _minDate ]]" max$="[[ _maxDate ]]">
 			</paper-input-container>
 			<paper-input-container always-float-label>
-				<label hidden\$="[[ !timeLabel ]]" slot="label" aria-hidden="true" for="timeInput">[[ timeLabel ]]</label>
-				<input id="timeInput" type="time" slot="input" value="{{ time::input }}" step="[[ step ]]" min\$="[[ _minTime ]]" max\$="[[ _maxTime ]]">
+				<label hidden$="[[ !timeLabel ]]" slot="label" aria-hidden="true" for="timeInput">[[ timeLabel ]]</label>
+				<input id="timeInput" type="time" slot="input" value="{{ time::input }}" step="[[ step ]]" min$="[[ _minTime ]]" max$="[[ _maxTime ]]">
 			</paper-input-container>
 		</div>
 `;


### PR DESCRIPTION
https://github.com/Neovici/cosmoz-frontend/issues/1314